### PR TITLE
Update views initiative type

### DIFF
--- a/decidim-initiatives/app/controllers/concerns/decidim/initiatives/single_initiative_type.rb
+++ b/decidim-initiatives/app/controllers/concerns/decidim/initiatives/single_initiative_type.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "active_support/concern"
+
+module Decidim
+  module Initiatives
+    # Common methods for elements that need specific behaviour when there is only one initiative type.
+    module SingleInitiativeType
+      extend ActiveSupport::Concern
+
+      included do
+        helper_method :single_initiative_type?
+
+        private
+
+        def current_organization_initiatives_type
+          Decidim::InitiativesType.where(organization: current_organization)
+        end
+
+        def single_initiative_type?
+          current_organization_initiatives_type.count == 1
+        end
+      end
+    end
+  end
+end

--- a/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/admin/initiatives_controller.rb
@@ -8,6 +8,7 @@ module Decidim
       # Controller used to manage the initiatives
       class InitiativesController < Decidim::Initiatives::Admin::ApplicationController
         include Decidim::Initiatives::NeedsInitiative
+        include Decidim::Initiatives::SingleInitiativeType
         include Decidim::Initiatives::TypeSelectorOptions
         include Decidim::Initiatives::Admin::Filterable
 

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -12,6 +12,7 @@ module Decidim
       include Decidim::FormFactory
       include InitiativeHelper
       include TypeSelectorOptions
+      include SingleInitiativeType
 
       helper Decidim::Admin::IconLinkHelper
       helper InitiativeHelper
@@ -20,7 +21,6 @@ module Decidim
       helper_method :current_initiative
       helper_method :initiative_type
       helper_method :promotal_committee_required?
-      helper_method :single_initiative_type?
 
       steps :select_initiative_type,
             :previous_form,
@@ -135,14 +135,6 @@ module Decidim
 
       def current_initiative
         Initiative.find(session_initiative[:id]) if session_initiative.has_key?(:id)
-      end
-
-      def current_organization_initiatives_type
-        Decidim::InitiativesType.where(organization: current_organization)
-      end
-
-      def single_initiative_type?
-        current_organization_initiatives_type.count == 1
       end
 
       def initiative_type

--- a/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
+++ b/decidim-initiatives/app/controllers/decidim/initiatives/create_initiative_controller.rb
@@ -20,6 +20,7 @@ module Decidim
       helper_method :current_initiative
       helper_method :initiative_type
       helper_method :promotal_committee_required?
+      helper_method :single_initiative_type?
 
       steps :select_initiative_type,
             :previous_form,
@@ -43,7 +44,7 @@ module Decidim
       def select_initiative_type_step(_parameters)
         session[:initiative] = {}
 
-        if single_initiative?
+        if single_initiative_type?
           redirect_to next_wizard_path
           return
         end
@@ -115,8 +116,8 @@ module Decidim
       end
 
       def build_form(klass, parameters)
-        @form = if single_initiative?
-                  form(klass).from_params(parameters.merge(type_id: current_organization_initiatives.first.id))
+        @form = if single_initiative_type?
+                  form(klass).from_params(parameters.merge(type_id: current_organization_initiatives_type.first.id))
                 else
                   form(klass).from_params(parameters)
                 end
@@ -136,12 +137,12 @@ module Decidim
         Initiative.find(session_initiative[:id]) if session_initiative.has_key?(:id)
       end
 
-      def current_organization_initiatives
+      def current_organization_initiatives_type
         Decidim::InitiativesType.where(organization: current_organization)
       end
 
-      def single_initiative?
-        current_organization_initiatives.count == 1
+      def single_initiative_type?
+        current_organization_initiatives_type.count == 1
       end
 
       def initiative_type

--- a/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/admin/initiatives/_form.html.erb
@@ -22,6 +22,7 @@
     </div>
 
     <div class="row">
+      <% unless single_initiative_type? %>
       <div class="columns xlarge-6">
         <%= form.select :type_id,
                         initiative_type_options,
@@ -36,7 +37,7 @@
                           "data-signature-types-search-url": decidim_initiatives.initiative_type_signature_types_search_url
                         } %>
       </div>
-
+      <% end %>
       <div class="columns xlarge-6">
         <%= form.select :decidim_scope_id, [], {}, { disabled: !@form.signature_type_updatable? } %>
       </div>

--- a/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
+++ b/decidim-initiatives/app/views/decidim/initiatives/create_initiative/fill_data.html.erb
@@ -21,12 +21,12 @@
         <%= decidim_form_for(@form, url: next_wizard_path, method: :put, html: { class: "form new_initiative_form" }) do |f| %>
           <%= f.hidden_field :type_id %>
           <div class=section>
-            <div class="field">
-              <label for="type_description">
-                <%= t ".initiative_type" %>
+            <% unless single_initiative_type? %>
+              <div class="field">
+                <label for="type_description"><%= t ".initiative_type" %></label>
                 <%= text_field_tag :type_description, strip_tags(translated_attribute(initiative_type.title)), readonly: true %>
-              </label>
-            </div>
+              </div>
+            <% end %>
 
             <div class="field">
               <%= f.text_field :title, autofocus: true, required: true %>

--- a/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/_initiative_creation_header.html.erb
@@ -13,6 +13,7 @@
     <ol class="wizard__steps">
       <% wizard_steps.each do |wizard_step| %>
         <% next if wizard_step.to_s == "promotal_committee" && !promotal_committee_required? %>
+        <% next if wizard_step.to_s == "select_initiative_type" && single_initiative_type? %>
         <% if step == wizard_step %>
           <li class="step--active">
             <%= t(".#{wizard_step}") %>

--- a/decidim-initiatives/app/views/layouts/decidim/initiative_creation.html.erb
+++ b/decidim-initiatives/app/views/layouts/decidim/initiative_creation.html.erb
@@ -3,7 +3,6 @@
     <div class="wrapper">
     <%= yield %>
     </div>
-    </div>
   <% else %>
     <div class="wrapper">
       <div class="row">

--- a/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/admin/update_initiative_spec.rb
@@ -117,6 +117,24 @@ describe "User prints the initiative", type: :system do
           end
         end
       end
+
+      context "when there is a single initiative type" do
+        let!(:other_initiatives_type) { nil }
+        let!(:other_initiatives_type_scope) { nil }
+
+        before do
+          initiative.created!
+        end
+
+        it "update of type, scope and signature type are disabled" do
+          page.find(".action-icon--edit").click
+
+          within ".edit_initiative" do
+            expect(page).not_to have_css("label[for='initiative_type_id']")
+            expect(page).not_to have_css("#initiative_type_id")
+          end
+        end
+      end
     end
   end
 end

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -98,6 +98,12 @@ describe "Initiative", type: :system do
           expect(page).not_to have_current_path(decidim_initiatives.create_initiative_path(id: :select_initiative_type))
         end
 
+        it "doesn't displays the 'choose' step" do
+          within ".wizard__steps" do
+            expect(page).not_to have_content("Choose")
+          end
+        end
+
         it "Has a hidden field with the selected initiative type" do
           expect(page).to have_xpath("//input[@id='initiative_type_id']", visible: false)
           expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)

--- a/decidim-initiatives/spec/system/create_initiative_spec.rb
+++ b/decidim-initiatives/spec/system/create_initiative_spec.rb
@@ -98,7 +98,7 @@ describe "Initiative", type: :system do
           expect(page).not_to have_current_path(decidim_initiatives.create_initiative_path(id: :select_initiative_type))
         end
 
-        it "doesn't displays the 'choose' step" do
+        it "doesn't display the 'choose' step" do
           within ".wizard__steps" do
             expect(page).not_to have_content("Choose")
           end
@@ -153,40 +153,57 @@ describe "Initiative", type: :system do
       context "when Create initiative" do
         let(:initiative) { build(:initiative) }
 
-        before do
-          find_button("I want to promote this initiative").click
-          fill_in "Title", with: translated(initiative.title, locale: :en)
-          fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
-          find_button("Continue").click
-        end
+        context "when there is several initiatives type" do
+          before do
+            find_button("I want to promote this initiative").click
+            fill_in "Title", with: translated(initiative.title, locale: :en)
+            fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
+            find_button("Continue").click
+          end
 
-        it "Create view is shown" do
-          expect(page).to have_content("Create")
-        end
+          it "Create view is shown" do
+            expect(page).to have_content("Create")
+          end
 
-        it "Offers contextual help" do
-          within ".callout.secondary" do
-            expect(page).to have_content("Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?")
-            expect(page).to have_content("You have to choose the type of signature. In-person, online or a combination of both")
-            expect(page).to have_content("Which is the geographic scope of the initiative? City, district?")
+          it "Offers contextual help" do
+            within ".callout.secondary" do
+              expect(page).to have_content("Review the content of your initiative. Is your title easy to understand? Is the objective of your initiative clear?")
+              expect(page).to have_content("You have to choose the type of signature. In-person, online or a combination of both")
+              expect(page).to have_content("Which is the geographic scope of the initiative? City, district?")
+            end
+          end
+
+          it "Information collected in previous steps is already filled" do
+            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+            expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
+            expect(find(:xpath, "//input[@id='initiative_description']", visible: false).value).to eq(translated(initiative.description, locale: :en))
+          end
+
+          context "when only one signature collection and scope are available" do
+            let(:other_initiative_type_scope) { nil }
+            let(:initiative_type) { create(:initiatives_type, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+
+            it "hides and automatically selects the values" do
+              expect(page).not_to have_content("Signature collection type")
+              expect(page).not_to have_content("Scope")
+              expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
+              expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: false).value).to eq("offline")
+            end
           end
         end
 
-        it "Information collected in previous steps is already filled" do
-          expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
-          expect(find(:xpath, "//input[@id='initiative_title']").value).to eq(translated(initiative.title, locale: :en))
-          expect(find(:xpath, "//input[@id='initiative_description']", visible: false).value).to eq(translated(initiative.description, locale: :en))
-        end
+        context "when there is only one initiative type" do
+          let!(:other_initiative_type) { nil }
 
-        context "when only one signature collection and scope are available" do
-          let(:other_initiative_type_scope) { nil }
-          let(:initiative_type) { create(:initiatives_type, organization: organization, minimum_committee_members: initiative_type_minimum_committee_members, signature_type: "offline") }
+          before do
+            fill_in "Title", with: translated(initiative.title, locale: :en)
+            fill_in_editor "initiative_description", with: translated(initiative.description, locale: :en)
+            find_button("Continue").click
+          end
 
-          it "hides and automatically selects the values" do
-            expect(page).not_to have_content("Signature collection type")
-            expect(page).not_to have_content("Scope")
-            expect(find(:xpath, "//input[@id='initiative_type_id']", visible: false).value).to eq(initiative_type.id.to_s)
-            expect(find(:xpath, "//input[@id='initiative_signature_type']", visible: false).value).to eq("offline")
+          it "have no 'Initiative type' grey field" do
+            expect(page).not_to have_content("Initiative type")
+            expect(page).not_to have_css("#type_description")
           end
         end
       end


### PR DESCRIPTION
#### :tophat: What? Why?

Hide some fields when there is only one Initiative type to improve the user experience.

#### :pushpin: Related Issues
- Related to comment - https://github.com/decidim/decidim/pull/5835#issuecomment-605998244

#### :clipboard: Subtasks
When there is only one initiative type 

- [x] Hide 'choose' field in wizard steps
- [x] Hide the select list for this unique type in create step 
- [x] Hide the select list for this unique type in backoffice Initiative form
- [x] Move single initiative type logic in a concern
- [x] Light rename of single_initiative? in single_initiative_type? according to review suggestion
- [x] Add tests
