### PR TITLE
light refactor assemblies sorting in assemblies spec

### DIFF
--- a/decidim-assemblies/app/queries/decidim/assemblies/parent_assemblies_for_select.rb
+++ b/decidim-assemblies/app/queries/decidim/assemblies/parent_assemblies_for_select.rb
@@ -15,6 +15,9 @@ module Decidim
         @assembly = assembly
       end
 
+      # Finds the available assemblies
+      #
+      # Returns an ActiveRecord::Relation.
       def query
         available_assemblies = Assembly.where(organization: @organization).where.not(id: @assembly)
 

--- a/decidim-assemblies/spec/queries/parent_assemblies_for_select_spec.rb
+++ b/decidim-assemblies/spec/queries/parent_assemblies_for_select_spec.rb
@@ -15,7 +15,7 @@ module Decidim::Assemblies
     describe "query" do
       it "returns assemblies that can be parent" do
         expect(subject.count).to eq(3)
-        expect(subject).to eq(assemblies)
+        expect(subject).to eq(assemblies.reverse)
       end
 
       context "when assembly is nil" do

--- a/decidim-assemblies/spec/queries/parent_assemblies_for_select_spec.rb
+++ b/decidim-assemblies/spec/queries/parent_assemblies_for_select_spec.rb
@@ -15,7 +15,7 @@ module Decidim::Assemblies
     describe "query" do
       it "returns assemblies that can be parent" do
         expect(subject.count).to eq(3)
-        expect(subject).to eq(assemblies.reverse)
+        expect(subject.sort).to eq(assemblies.sort)
       end
 
       context "when assembly is nil" do

--- a/decidim-assemblies/spec/queries/parent_assemblies_for_select_spec.rb
+++ b/decidim-assemblies/spec/queries/parent_assemblies_for_select_spec.rb
@@ -15,7 +15,7 @@ module Decidim::Assemblies
     describe "query" do
       it "returns assemblies that can be parent" do
         expect(subject.count).to eq(3)
-        expect(subject.sort).to eq(assemblies.sort)
+        expect(subject).to match_array(assemblies)
       end
 
       context "when assembly is nil" do


### PR DESCRIPTION
#### :tophat: What? Why?

A test seems to fail because of array content order. So I decided to suggest a light update in specs.

#### :clipboard: Subtasks
- [x] Add documentation for method
- [x] update tests
