### PR TITLE
Batch notifications in email feature

### DIFF
--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/create_assembly_member.rb
@@ -73,9 +73,7 @@ module Decidim
             event_class: Decidim::Assemblies::CreateAssemblyMemberEvent,
             resource: assembly,
             followers: [form.user],
-            extra: {
-              high_priority: true
-            }
+            priority: "now"
           }
           Decidim::EventsManager.publish(data)
         end

--- a/decidim-assemblies/app/commands/decidim/assemblies/admin/notify_role_assigned_to_assembly.rb
+++ b/decidim-assemblies/app/commands/decidim/assemblies/admin/notify_role_assigned_to_assembly.rb
@@ -11,9 +11,9 @@ module Decidim
             event_class: Decidim::RoleAssignedToAssemblyEvent,
             resource: form.current_participatory_space,
             affected_users: [user],
+            priority: "now",
             extra: {
-              role: form.role,
-              high_priority: true
+              role: form.role
             }
           )
         end

--- a/decidim-assemblies/spec/commands/create_assembly_admin_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_admin_spec.rb
@@ -28,9 +28,9 @@ module Decidim::Assemblies
         event_class: Decidim::RoleAssignedToAssemblyEvent,
         resource: my_assembly,
         affected_users: [user],
+        priority: "now",
         extra: {
-          role: kind_of(String),
-          high_priority: true
+          role: kind_of(String)
         }
       }
     end

--- a/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
+++ b/decidim-assemblies/spec/commands/create_assembly_member_spec.rb
@@ -83,9 +83,7 @@ module Decidim::Assemblies
               event_class: Decidim::Assemblies::CreateAssemblyMemberEvent,
               resource: assembly,
               followers: a_collection_containing_exactly(user),
-              extra: {
-                high_priority: true
-              }
+              priority: "now"
             )
 
           subject.call

--- a/decidim-assemblies/spec/commands/update_assembly_admin_spec.rb
+++ b/decidim-assemblies/spec/commands/update_assembly_admin_spec.rb
@@ -28,9 +28,9 @@ module Decidim::Assemblies
         event_class: Decidim::RoleAssignedToAssemblyEvent,
         resource: my_assembly,
         affected_users: [user_role.user],
+        priority: "now",
         extra: {
-          role: kind_of(String),
-          high_priority: true
+          role: kind_of(String)
         }
       }
     end

--- a/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
+++ b/decidim-comments/app/services/decidim/comments/new_comment_notification_creator.rb
@@ -112,9 +112,9 @@ module Decidim
           event: "decidim.events.comments.#{event}",
           event_class: event_class,
           resource: comment.root_commentable,
+          priority: "now",
           extra: {
-            comment_id: comment.id,
-            high_priority: true
+            comment_id: comment.id
           }
         }.deep_merge(users)
 

--- a/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
+++ b/decidim-comments/spec/services/decidim/comments/new_comment_notification_creator_spec.rb
@@ -57,9 +57,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
           event_class: Decidim::Comments::UserMentionedEvent,
           resource: dummy_resource,
           affected_users: a_collection_containing_exactly(*mentioned_users),
+          priority: "now",
           extra: {
-            comment_id: comment.id,
-            high_priority: true
+            comment_id: comment.id
           }
         )
       expect(Decidim::EventsManager)
@@ -99,9 +99,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
             event_class: Decidim::Comments::UserMentionedEvent,
             resource: dummy_resource,
             affected_users: a_collection_containing_exactly(*mentioned_users_to_notify),
+            priority: "now",
             extra: {
-              comment_id: comment.id,
-              high_priority: true
+              comment_id: comment.id
             }
           )
         expect(Decidim::EventsManager)
@@ -146,10 +146,10 @@ describe Decidim::Comments::NewCommentNotificationCreator do
             event_class: Decidim::Comments::UserGroupMentionedEvent,
             resource: dummy_resource,
             affected_users: a_collection_containing_exactly(*affected_group_users),
+            priority: "now",
             extra: {
               comment_id: comment.id,
-              group: group,
-              high_priority: true
+              group: group
             }
           )
         expect(Decidim::EventsManager)
@@ -186,9 +186,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
               event_class: Decidim::Comments::UserMentionedEvent,
               resource: dummy_resource,
               affected_users: a_collection_containing_exactly(*mentioned_users),
+              priority: "now",
               extra: {
-                comment_id: comment.id,
-                high_priority: true
+                comment_id: comment.id
               }
             )
           expect(Decidim::EventsManager)
@@ -200,6 +200,7 @@ describe Decidim::Comments::NewCommentNotificationCreator do
               event_class: Decidim::Comments::UserGroupMentionedEvent,
               resource: dummy_resource,
               affected_users: a_collection_containing_exactly(*affected_group_users),
+              priority: "now",
               extra: {
                 comment_id: comment.id,
                 group: group
@@ -234,10 +235,10 @@ describe Decidim::Comments::NewCommentNotificationCreator do
               event_class: Decidim::Comments::UserGroupMentionedEvent,
               resource: dummy_resource,
               affected_users: a_collection_containing_exactly(*affected_group_users),
+              priority: "now",
               extra: {
                 comment_id: comment.id,
-                group: group,
-                high_priority: true
+                group: group
               }
             )
 
@@ -266,9 +267,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
           event_class: Decidim::Comments::CommentByFollowedUserEvent,
           resource: dummy_resource,
           followers: a_collection_containing_exactly(user_following_comment_author),
+          priority: "now",
           extra: {
-            comment_id: comment.id,
-            high_priority: true
+            comment_id: comment.id
           }
         )
       expect(Decidim::EventsManager)
@@ -294,9 +295,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
           event_class: Decidim::Comments::CommentCreatedEvent,
           resource: dummy_resource,
           followers: a_collection_containing_exactly(*commentable_recipients),
+          priority: "now",
           extra: {
-            comment_id: comment.id,
-            high_priority: true
+            comment_id: comment.id
           }
         )
 
@@ -329,9 +330,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
             event_class: Decidim::Comments::CommentCreatedEvent,
             resource: dummy_resource,
             followers: a_collection_containing_exactly(commentable_recipient, commentable_author),
+            priority: "now",
             extra: {
-              comment_id: comment.id,
-              high_priority: true
+              comment_id: comment.id
             }
           )
 
@@ -353,9 +354,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
               event_class: Decidim::Comments::ReplyCreatedEvent,
               resource: dummy_resource,
               affected_users: [comment_author],
+              priority: "now",
               extra: {
-                comment_id: comment.id,
-                high_priority: true
+                comment_id: comment.id
               }
             )
 
@@ -382,9 +383,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
               event_class: Decidim::Comments::ReplyCreatedEvent,
               resource: dummy_resource,
               affected_users: a_collection_containing_exactly(top_level_comment_author),
+              priority: "now",
               extra: {
-                comment_id: comment.id,
-                high_priority: true
+                comment_id: comment.id
               }
             )
 
@@ -418,9 +419,9 @@ describe Decidim::Comments::NewCommentNotificationCreator do
           event_class: Decidim::Comments::CommentByFollowedUserGroupEvent,
           resource: dummy_resource,
           followers: a_collection_containing_exactly(user_following_user_group),
+          priority: "now",
           extra: {
-            comment_id: user_group_comment.id,
-            high_priority: true
+            comment_id: user_group_comment.id
           }
         )
       expect(Decidim::EventsManager)

--- a/decidim-core/app/commands/decidim/accept_user_group_join_request.rb
+++ b/decidim-core/app/commands/decidim/accept_user_group_join_request.rb
@@ -43,10 +43,10 @@ module Decidim
         event_class: JoinRequestAcceptedEvent,
         resource: membership.user_group,
         affected_users: [membership.user],
+        priority: "now",
         extra: {
           user_group_name: membership.user_group.name,
-          user_group_nickname: membership.user_group.nickname,
-          high_priority: true
+          user_group_nickname: membership.user_group.nickname
         }
       )
     end

--- a/decidim-core/app/commands/decidim/create_user_group.rb
+++ b/decidim-core/app/commands/decidim/create_user_group.rb
@@ -61,9 +61,7 @@ module Decidim
         event_class: Decidim::UserGroupCreatedEvent,
         resource: @user_group,
         affected_users: Decidim::User.org_admins_except_me(form.current_user),
-        extra: {
-          high_priority: true
-        }
+        priority: "now"
       }
 
       Decidim::EventsManager.publish(data)

--- a/decidim-core/app/commands/decidim/invite_user_to_group.rb
+++ b/decidim-core/app/commands/decidim/invite_user_to_group.rb
@@ -48,10 +48,10 @@ module Decidim
         event_class: InvitedToGroupEvent,
         resource: user_group,
         affected_users: [form.user],
+        priority: "now",
         extra: {
           user_group_name: user_group.name,
-          user_group_nickname: user_group.nickname,
-          high_priority: true
+          user_group_nickname: user_group.nickname
         }
       )
     end

--- a/decidim-core/app/commands/decidim/join_user_group.rb
+++ b/decidim-core/app/commands/decidim/join_user_group.rb
@@ -47,10 +47,10 @@ module Decidim
         event_class: JoinRequestCreatedEvent,
         resource: user_group,
         affected_users: user_group.managers,
+        priority: "now",
         extra: {
           user_group_name: user_group.name,
-          user_group_nickname: user_group.nickname,
-          high_priority: true
+          user_group_nickname: user_group.nickname
         }
       )
     end

--- a/decidim-core/app/commands/decidim/promote_membership.rb
+++ b/decidim-core/app/commands/decidim/promote_membership.rb
@@ -45,10 +45,10 @@ module Decidim
         event_class: PromotedToAdminEvent,
         resource: membership.user_group,
         affected_users: [membership.user],
+        priority: "now",
         extra: {
           user_group_name: membership.user_group.name,
-          user_group_nickname: membership.user_group.nickname,
-          high_priority: true
+          user_group_nickname: membership.user_group.nickname
         }
       )
     end

--- a/decidim-core/app/commands/decidim/reject_user_group_join_request.rb
+++ b/decidim-core/app/commands/decidim/reject_user_group_join_request.rb
@@ -43,10 +43,10 @@ module Decidim
         event_class: JoinRequestRejectedEvent,
         resource: membership.user_group,
         affected_users: [membership.user],
+        priority: "now",
         extra: {
           user_group_name: membership.user_group.name,
-          user_group_nickname: membership.user_group.nickname,
-          high_priority: true
+          user_group_nickname: membership.user_group.nickname
         }
       )
     end

--- a/decidim-core/app/commands/decidim/remove_user_from_group.rb
+++ b/decidim-core/app/commands/decidim/remove_user_from_group.rb
@@ -43,10 +43,10 @@ module Decidim
         event_class: RemovedFromGroupEvent,
         resource: membership.user_group,
         affected_users: [membership.user],
+        priority: "now",
         extra: {
           user_group_name: membership.user_group.name,
-          user_group_nickname: membership.user_group.nickname,
-          high_priority: true
+          user_group_nickname: membership.user_group.nickname
         }
       )
     end

--- a/decidim-core/app/commands/decidim/update_user_group.rb
+++ b/decidim-core/app/commands/decidim/update_user_group.rb
@@ -58,9 +58,7 @@ module Decidim
         event_class: Decidim::UserGroupUpdatedEvent,
         resource: @user_group,
         affected_users: Decidim::User.org_admins_except_me(form.current_user),
-        extra: {
-          high_priority: true
-        }
+        priority: "now"
       }
 
       Decidim::EventsManager.publish(data)

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -53,7 +53,6 @@ module Decidim
         data[:resource],
         data[:followers],
         data[:affected_users],
-        data[:priority],
         data[:extra]
       )
     end

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -53,16 +53,17 @@ module Decidim
         data[:resource],
         data[:followers],
         data[:affected_users],
+        data[:priority],
         data[:extra]
       )
     end
 
     # Allows to defined whether an event as to be sent now or to be scheduled
     # Returns boolean
-    #   - False if high_priority is undefined, unknown or false
-    #   - True if high_priority? is high
+    #   - False if high_priority is undefined, unknown or different to :now
+    #   - True if high_priority? is equals to :now
     def high_priority?(data)
-      data[:extra].fetch(:high_priority, false) # If not defined, high_priority is false by default
+      data[:priority] == :now
     end
   end
 end

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -63,6 +63,11 @@ module Decidim
     #   - False if high_priority is undefined, unknown or different to :now
     #   - True if high_priority? is equals to :now
     def high_priority?(data)
+      return false if data[:priority].blank?
+      data[:priority] = data[:priority].to_sym if data[:priority].is_a? String
+
+      return false unless Decidim::Notification.priorities.include? data[:priority]
+
       data[:priority] == :now
     end
   end

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -64,6 +64,7 @@ module Decidim
     #   - True if high_priority? is equals to :now
     def high_priority?(data)
       return false if data[:priority].blank?
+
       data[:priority] = data[:priority].to_sym if data[:priority].is_a? String
 
       return false unless Decidim::Notification.priorities.include? data[:priority]

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -7,9 +7,12 @@ module Decidim
     belongs_to :resource, foreign_key: "decidim_resource_id", foreign_type: "decidim_resource_type", polymorphic: true
     belongs_to :user, foreign_key: "decidim_user_id", class_name: "Decidim::User"
 
+    enum priority: [:batch, :now]
+
     scope :unsent, -> { where(sent_at: nil) }
     scope :priority_level, ->(priority) { where("extra ->> 'priority' = ?", priority) }
     scope :from_last, ->(time) { where("created_at > ?", time.ago) }
+    scope :with_priority, ->(priority) { where(priority: priority) }
 
     def event_class_instance
       @event_class_instance ||= event_class.constantize.new(

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -10,8 +10,7 @@ module Decidim
     enum priority: [:batch, :now]
 
     scope :unsent, -> { where(sent_at: nil) }
-    scope :priority_level, ->(priority) { where("extra ->> 'priority' = ?", priority) }
-    scope :from_last, ->(time) { where("created_at > ?", time.ago) }
+    scope :not_expired, ->(time) { where("created_at > ?", time.ago) }
     scope :with_priority, ->(priority) { where(priority: priority) }
 
     def event_class_instance

--- a/decidim-core/app/services/decidim/batch_email_notifications_generator.rb
+++ b/decidim-core/app/services/decidim/batch_email_notifications_generator.rb
@@ -28,7 +28,7 @@ module Decidim
     private
 
     def events
-      @events ||= Decidim::Notification.from_last(Decidim.config.batch_email_notifications_interval)
+      @events ||= Decidim::Notification.not_expired(Decidim.config.batch_email_notifications_expired)
                                        .unsent
                                        .with_priority(:batch)
                                        .order(created_at: :desc)

--- a/decidim-core/app/services/decidim/batch_email_notifications_generator.rb
+++ b/decidim-core/app/services/decidim/batch_email_notifications_generator.rb
@@ -30,7 +30,7 @@ module Decidim
     def events
       @events ||= Decidim::Notification.from_last(Decidim.config.batch_email_notifications_interval)
                                        .unsent
-                                       .priority_level("low")
+                                       .with_priority(:batch)
                                        .order(created_at: :desc)
                                        .limit(Decidim.config.batch_email_notifications_max_length)
     end
@@ -46,6 +46,7 @@ module Decidim
           event_class: event.event_class,
           event_name: event.event_name,
           user: event.user,
+          priority: event.priority,
           extra: event.extra,
           user_role: event.user_role,
           created_at: time_ago_in_words(event.created_at).capitalize

--- a/decidim-core/app/services/decidim/events_manager.rb
+++ b/decidim-core/app/services/decidim/events_manager.rb
@@ -24,7 +24,7 @@ module Decidim
     #
     # Returns nothing.
     # rubocop:disable Metrics/ParameterLists
-    def self.publish(event:, event_class: Decidim::Events::BaseEvent, resource:, affected_users: [], followers: [], extra: {}, force_send: false)
+    def self.publish(event:, event_class: Decidim::Events::BaseEvent, resource:, affected_users: [], followers: [], extra: {}, force_send: false, priority: :batch)
       ActiveSupport::Notifications.publish(
         event,
         event_class: event_class.name,
@@ -32,6 +32,7 @@ module Decidim
         affected_users: affected_users.uniq.compact,
         followers: followers.uniq.compact,
         force_send: force_send,
+        priority: priority,
         extra: extra
       )
     end

--- a/decidim-core/app/services/decidim/events_manager.rb
+++ b/decidim-core/app/services/decidim/events_manager.rb
@@ -24,7 +24,7 @@ module Decidim
     #
     # Returns nothing.
     # rubocop:disable Metrics/ParameterLists
-    def self.publish(event:, event_class: Decidim::Events::BaseEvent, resource:, affected_users: [], followers: [], extra: {}, force_send: false, priority: :batch)
+    def self.publish(event:, event_class: Decidim::Events::BaseEvent, resource:, affected_users: [], followers: [], extra: {}, force_send: false, priority: "batch")
       ActiveSupport::Notifications.publish(
         event,
         event_class: event_class.name,

--- a/decidim-core/db/migrate/20201016080552_add_priority_to_notifications.rb
+++ b/decidim-core/db/migrate/20201016080552_add_priority_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddPriorityToNotifications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :notifications, :priority, :integer, null: false, default: 0
+  end
+end

--- a/decidim-core/db/migrate/20201016080552_add_priority_to_notifications.rb
+++ b/decidim-core/db/migrate/20201016080552_add_priority_to_notifications.rb
@@ -2,6 +2,6 @@
 
 class AddPriorityToNotifications < ActiveRecord::Migration[5.2]
   def change
-    add_column :notifications, :priority, :integer, null: false, default: 0
+    add_column :decidim_notifications, :priority, :integer, null: false, default: 0
   end
 end

--- a/decidim-core/db/migrate/20201016080552_add_priority_to_notifications.rb
+++ b/decidim-core/db/migrate/20201016080552_add_priority_to_notifications.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddPriorityToNotifications < ActiveRecord::Migration[5.2]
   def change
     add_column :notifications, :priority, :integer, null: false, default: 0

--- a/decidim-core/lib/decidim/core.rb
+++ b/decidim-core/lib/decidim/core.rb
@@ -271,9 +271,9 @@ module Decidim
     false
   end
 
-  # Interval between each notification mail batch
-  config_accessor :batch_email_notifications_interval do
-    24.hours
+  # Time when the notification is considered as expired
+  config_accessor :batch_email_notifications_expired do
+    1.week
   end
 
   # Maximum of notifications in a mail.

--- a/decidim-core/lib/decidim/core/test/factories.rb
+++ b/decidim-core/lib/decidim/core/test/factories.rb
@@ -565,26 +565,15 @@ FactoryBot.define do
     resource { build(:dummy_resource) }
     event_name { resource.class.name.underscore.tr("/", ".") }
     event_class { "Decidim::DummyResourceEvent" }
+    priority { :batch }
     extra do
       {
         some_extra_data: "1"
       }
     end
 
-    trait :high_priority do
-      extra do
-        {
-          priority: :high
-        }
-      end
-    end
-
-    trait :low_priority do
-      extra do
-        {
-          priority: :low
-        }
-      end
+    trait :now_priority do
+      priority { :now }
     end
   end
 

--- a/decidim-core/spec/commands/decidim/accept_user_group_join_request_spec.rb
+++ b/decidim-core/spec/commands/decidim/accept_user_group_join_request_spec.rb
@@ -38,10 +38,10 @@ module Decidim
                 event_class: JoinRequestAcceptedEvent,
                 resource: membership.user_group,
                 affected_users: [membership.user],
+                priority: "now",
                 extra: {
                   user_group_name: membership.user_group.name,
-                  user_group_nickname: membership.user_group.nickname,
-                  high_priority: true
+                  user_group_nickname: membership.user_group.nickname
                 }
               )
             )

--- a/decidim-core/spec/commands/decidim/create_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/create_user_group_spec.rb
@@ -95,9 +95,7 @@ module Decidim
                 event_class: Decidim::UserGroupCreatedEvent,
                 resource: an_object_satisfying { |obj| obj.is_a?(Decidim::UserGroup) },
                 affected_users: a_collection_containing_exactly(*Decidim::User.where(organization: organization, admin: true).all),
-                extra: {
-                  high_priority: true
-                }
+                priority: "now"
               )
 
             command.call

--- a/decidim-core/spec/commands/decidim/invite_user_to_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/invite_user_to_group_spec.rb
@@ -74,10 +74,10 @@ module Decidim
                 event_class: InvitedToGroupEvent,
                 resource: user_group,
                 affected_users: [user],
+                priority: "now",
                 extra: {
                   user_group_name: user_group.name,
-                  user_group_nickname: user_group.nickname,
-                  high_priority: true
+                  user_group_nickname: user_group.nickname
                 }
               )
             )

--- a/decidim-core/spec/commands/decidim/join_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/join_user_group_spec.rb
@@ -56,10 +56,10 @@ module Decidim
                 event_class: JoinRequestCreatedEvent,
                 resource: user_group,
                 affected_users: affected_users,
+                priority: "now",
                 extra: {
                   user_group_name: user_group.name,
-                  user_group_nickname: user_group.nickname,
-                  high_priority: true
+                  user_group_nickname: user_group.nickname
                 }
               )
             )

--- a/decidim-core/spec/commands/decidim/promote_membership_spec.rb
+++ b/decidim-core/spec/commands/decidim/promote_membership_spec.rb
@@ -56,10 +56,10 @@ module Decidim
                 event_class: PromotedToAdminEvent,
                 resource: membership.user_group,
                 affected_users: [membership.user],
+                priority: "now",
                 extra: {
                   user_group_name: membership.user_group.name,
-                  user_group_nickname: membership.user_group.nickname,
-                  high_priority: true
+                  user_group_nickname: membership.user_group.nickname
                 }
               )
             )

--- a/decidim-core/spec/commands/decidim/reject_user_group_join_request_spec.rb
+++ b/decidim-core/spec/commands/decidim/reject_user_group_join_request_spec.rb
@@ -37,10 +37,10 @@ module Decidim
                 event_class: JoinRequestRejectedEvent,
                 resource: membership.user_group,
                 affected_users: [membership.user],
+                priority: "now",
                 extra: {
                   user_group_name: membership.user_group.name,
-                  user_group_nickname: membership.user_group.nickname,
-                  high_priority: true
+                  user_group_nickname: membership.user_group.nickname
                 }
               )
             )

--- a/decidim-core/spec/commands/decidim/remove_user_from_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/remove_user_from_group_spec.rb
@@ -51,10 +51,10 @@ module Decidim
                 event_class: RemovedFromGroupEvent,
                 resource: membership.user_group,
                 affected_users: [membership.user],
+                priority: "now",
                 extra: {
                   user_group_name: membership.user_group.name,
-                  user_group_nickname: membership.user_group.nickname,
-                  high_priority: true
+                  user_group_nickname: membership.user_group.nickname
                 }
               )
             )

--- a/decidim-core/spec/commands/decidim/update_user_group_spec.rb
+++ b/decidim-core/spec/commands/decidim/update_user_group_spec.rb
@@ -94,9 +94,7 @@ module Decidim
                   event_class: Decidim::UserGroupUpdatedEvent,
                   resource: user_group,
                   affected_users: a_collection_containing_exactly(*Decidim::User.where(organization: organization, admin: true).all),
-                  extra: {
-                    high_priority: true
-                  }
+                  priority: "now"
                 )
 
               command.call

--- a/decidim-core/spec/jobs/decidim/batch_email_notifications_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/batch_email_notifications_generator_job_spec.rb
@@ -14,30 +14,34 @@ describe Decidim::BatchEmailNotificationsGeneratorJob do
   describe "perform" do
     let(:generator) { double :generator }
 
-    context "when batch email notifications disabled" do
+    it "doesn't delegates the work to the class" do
+      expect(Decidim::BatchEmailNotificationsGenerator)
+        .not_to receive(:new)
+
+      expect(generator)
+        .not_to receive(:generate)
+
+      subject.perform_now
+    end
+
+    context "when batch email notifications is enabled" do
       before do
+        Decidim.config.batch_email_notifications_enabled = true
+      end
+
+      after do
         Decidim.config.batch_email_notifications_enabled = false
       end
 
-      it "doesn't delegates the work to the class" do
+      it "delegates the work to the class" do
         expect(Decidim::BatchEmailNotificationsGenerator)
-          .not_to receive(:new)
-
+          .to receive(:new)
+          .and_return(generator)
         expect(generator)
-          .not_to receive(:generate)
+          .to receive(:generate)
 
         subject.perform_now
       end
-    end
-
-    it "delegates the work to the class" do
-      expect(Decidim::BatchEmailNotificationsGenerator)
-        .to receive(:new)
-        .and_return(generator)
-      expect(generator)
-        .to receive(:generate)
-
-      subject.perform_now
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/event_publisher_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/event_publisher_job_spec.rb
@@ -5,6 +5,28 @@ require "spec_helper"
 describe Decidim::EventPublisherJob do
   subject { described_class }
 
+  shared_examples_for "batch priority" do |priority, enqueues_jobs|
+    let(:priority) { priority }
+
+    context "when the priority is #{priority}" do
+      if enqueues_jobs == true
+        it "enqueues the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+          subject
+        end
+      else
+        it "doesn't enqueue the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+          subject
+        end
+      end
+    end
+  end
+
   describe "queue" do
     it "is queued to events" do
       expect(subject.queue_name).to eq "events"
@@ -18,14 +40,10 @@ describe Decidim::EventPublisherJob do
 
     let(:event_name) { "some_event" }
     let(:priority) { :batch }
-    let(:extra) do
-      {}
-    end
     let(:data) do
       {
         resource: resource,
-        priority: priority,
-        extra: extra
+        priority: priority
       }
     end
 
@@ -37,43 +55,41 @@ describe Decidim::EventPublisherJob do
           resource.published_at = Time.current
         end
 
-        context "when batch notifications in email is enabled" do
+        it "enqueues the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+          subject
+        end
+
+        context "and batch notifications is enabled" do
           before do
             Decidim.config.batch_email_notifications_enabled = true
           end
 
-          context "and priority level is not defined" do
-            it "enqueues the jobs" do
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
+
+          context "and priority is batch" do
+            it "enqueues the jobs except email" do
               expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
               expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
 
               subject
             end
-          end
 
-          context "and priority level is low" do
-            let(:extra) do
-              {
-                high_priority: false
-              }
-            end
+            context "and force_send is true" do
+              before do
+                data[:force_send] = true
+              end
 
-            it "enqueues the jobs" do
-              expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
-              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+              it "enqueues the jobs" do
+                expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+                expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
 
-              subject
-            end
-          end
-
-          context "and priority level is high" do
-            let(:priority) { :now }
-
-            it "enqueues the jobs" do
-              expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
-              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
-
-              subject
+                subject
+              end
             end
           end
         end
@@ -91,6 +107,20 @@ describe Decidim::EventPublisherJob do
           subject
         end
 
+        context "and batch notifications is enabled" do
+          before do
+            Decidim.config.batch_email_notifications_enabled = true
+          end
+
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
+
+          [:batch, :now].each do |priority|
+            it_behaves_like "batch priority", priority, false
+          end
+        end
+
         context "when #force_send is true" do
           before do
             data[:force_send] = true
@@ -102,17 +132,26 @@ describe Decidim::EventPublisherJob do
 
             subject
           end
+
+          context "and batch notifications is enabled" do
+            before do
+              Decidim.config.batch_email_notifications_enabled = true
+            end
+
+            after do
+              Decidim.config.batch_email_notifications_enabled = false
+            end
+
+            [:batch, :now].each do |priority|
+              it_behaves_like "batch priority", priority, true
+            end
+          end
         end
       end
     end
 
     context "when there's a component" do
       let(:resource) { build(:dummy_resource) }
-      let(:extra) do
-        {
-          high_priority: false
-        }
-      end
 
       context "when it is published" do
         before do
@@ -121,10 +160,40 @@ describe Decidim::EventPublisherJob do
         end
 
         it "enqueues the jobs" do
-          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
           expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
 
           subject
+        end
+
+        context "and batch notifications is enabled" do
+          before do
+            Decidim.config.batch_email_notifications_enabled = true
+          end
+
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
+
+          context "and priority is batch" do
+            it "enqueues the jobs except email" do
+              expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+              subject
+            end
+          end
+
+          context "and priority is now" do
+            let(:priority) { :now }
+
+            it "enqueues the jobs" do
+              expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+              subject
+            end
+          end
         end
       end
 
@@ -140,6 +209,20 @@ describe Decidim::EventPublisherJob do
 
           subject
         end
+
+        context "and batch notifications is enabled" do
+          before do
+            Decidim.config.batch_email_notifications_enabled = true
+          end
+
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
+
+          [:batch, :now].each do |priority|
+            it_behaves_like "batch priority", priority, false
+          end
+        end
       end
     end
 
@@ -153,10 +236,40 @@ describe Decidim::EventPublisherJob do
         end
 
         it "enqueues the jobs" do
-          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
           expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
 
           subject
+        end
+
+        context "and batch notifications is enabled" do
+          before do
+            Decidim.config.batch_email_notifications_enabled = true
+          end
+
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
+
+          context "and priority is batch" do
+            it "enqueues the jobs except email" do
+              expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+              subject
+            end
+          end
+
+          context "and priority is now" do
+            let(:priority) { :now }
+
+            it "enqueues the jobs" do
+              expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+              subject
+            end
+          end
         end
       end
 
@@ -172,49 +285,144 @@ describe Decidim::EventPublisherJob do
 
           subject
         end
+
+        context "and batch notifications is enabled" do
+          before do
+            Decidim.config.batch_email_notifications_enabled = true
+          end
+
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
+
+          [:batch, :now].each do |priority|
+            it_behaves_like "batch priority", priority, false
+          end
+        end
       end
-    end
 
-    context "when the resource is a component" do
-      let(:resource) { build(:component) }
+      context "when the resource is a component" do
+        let(:resource) { build(:component) }
 
-      it "enqueues the jobs" do
-        expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
-        expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
-
-        subject
-      end
-
-      context "when it is not published" do
-        let(:resource) { build(:component, :unpublished) }
-
-        it "doesn't enqueue the jobs" do
-          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
-          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+        it "enqueues the jobs" do
+          expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+          expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
 
           subject
         end
+
+        context "and batch notifications is enabled" do
+          before do
+            Decidim.config.batch_email_notifications_enabled = true
+          end
+
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
+
+          context "and priority is batch" do
+            it "enqueues the jobs except email" do
+              expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+              subject
+            end
+          end
+
+          context "and priority is now" do
+            let(:priority) { :now }
+
+            it "enqueues the jobs" do
+              expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+              subject
+            end
+          end
+        end
+
+        context "when it is not published" do
+          let(:resource) { build(:component, :unpublished) }
+
+          it "doesn't enqueue the jobs" do
+            expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+            expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+            subject
+          end
+
+          context "and batch notifications is enabled" do
+            before do
+              Decidim.config.batch_email_notifications_enabled = true
+            end
+
+            after do
+              Decidim.config.batch_email_notifications_enabled = false
+            end
+
+            [:batch, :now].each do |priority|
+              it_behaves_like "batch priority", priority, false
+            end
+          end
+        end
       end
-    end
 
-    context "when the resource is a participatory space" do
-      let(:resource) { build(:participatory_process) }
+      context "when the resource is a participatory space" do
+        let(:resource) { build(:participatory_process) }
 
-      it "enqueues the jobs" do
-        expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
-        expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+        context "and batch notifications is enabled" do
+          before do
+            Decidim.config.batch_email_notifications_enabled = true
+          end
 
-        subject
-      end
+          after do
+            Decidim.config.batch_email_notifications_enabled = false
+          end
 
-      context "when it is not published" do
-        let(:resource) { build(:participatory_process, :unpublished) }
+          context "and priority is batch" do
+            it "enqueues the jobs except email" do
+              expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
 
-        it "doesn't enqueue the jobs" do
-          expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
-          expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+              subject
+            end
+          end
 
-          subject
+          context "and priority is now" do
+            let(:priority) { :now }
+
+            it "enqueues the jobs" do
+              expect(Decidim::EmailNotificationGeneratorJob).to receive(:perform_later)
+              expect(Decidim::NotificationGeneratorJob).to receive(:perform_later)
+
+              subject
+            end
+          end
+        end
+
+        context "when it is not published" do
+          let(:resource) { build(:participatory_process, :unpublished) }
+
+          it "doesn't enqueue the jobs" do
+            expect(Decidim::EmailNotificationGeneratorJob).not_to receive(:perform_later)
+            expect(Decidim::NotificationGeneratorJob).not_to receive(:perform_later)
+
+            subject
+          end
+
+          context "and batch notifications is enabled" do
+            before do
+              Decidim.config.batch_email_notifications_enabled = true
+            end
+
+            after do
+              Decidim.config.batch_email_notifications_enabled = false
+            end
+
+            [:batch, :now].each do |priority|
+              it_behaves_like "batch priority", priority, false
+            end
+          end
         end
       end
     end

--- a/decidim-core/spec/models/decidim/notification_spec.rb
+++ b/decidim-core/spec/models/decidim/notification_spec.rb
@@ -24,25 +24,25 @@ module Decidim
       end
     end
 
-    describe "priority_level scope" do
-      let!(:low_notifications) { create_list(:notification, 4, :low_priority) }
-      let!(:high_notifications) { create_list(:notification, 4, :high_priority) }
+    describe "with_priority scope" do
+      let!(:batch_notifications) { create_list(:notification, 4) }
+      let!(:now_notifications) { create_list(:notification, 4, :now_priority) }
 
-      context "with low priority notifications" do
-        let(:priority_level) { :low }
+      context "with batch priority notifications" do
+        let(:priority_level) { :batch }
 
-        it "returns notifications with low priority" do
-          expect(described_class.priority_level(priority_level)).to match_array(low_notifications)
-          expect(described_class.priority_level(priority_level)).not_to match_array(high_notifications)
+        it "returns notifications with batch priority" do
+          expect(described_class.with_priority(priority)).to match_array(batch_notifications)
+          expect(described_class.with_priority(priority)).not_to match_array(now_notifications)
         end
       end
 
-      context "with low priority notifications" do
-        let(:priority_level) { :high }
+      context "with now priority notifications" do
+        let(:priority_level) { :now }
 
-        it "returns notifications with low priority" do
-          expect(described_class.priority_level(priority_level)).not_to match_array(low_notifications)
-          expect(described_class.priority_level(priority_level)).to match_array(high_notifications)
+        it "returns notifications with now priority" do
+          expect(described_class.with_priority(priority)).not_to match_array(batch_notifications)
+          expect(described_class.with_priority(priority)).to match_array(now_notifications)
         end
       end
 
@@ -50,7 +50,7 @@ module Decidim
         let(:priority_level) { nil }
 
         it "returns nothing" do
-          expect(described_class.priority_level(priority_level).count).to eq(0)
+          expect(described_class.with_priority(priority).count).to eq(0)
         end
       end
     end

--- a/decidim-core/spec/models/decidim/notification_spec.rb
+++ b/decidim-core/spec/models/decidim/notification_spec.rb
@@ -29,7 +29,7 @@ module Decidim
       let!(:now_notifications) { create_list(:notification, 4, :now_priority) }
 
       context "with batch priority notifications" do
-        let(:priority_level) { :batch }
+        let(:priority) { :batch }
 
         it "returns notifications with batch priority" do
           expect(described_class.with_priority(priority)).to match_array(batch_notifications)
@@ -38,7 +38,7 @@ module Decidim
       end
 
       context "with now priority notifications" do
-        let(:priority_level) { :now }
+        let(:priority) { :now }
 
         it "returns notifications with now priority" do
           expect(described_class.with_priority(priority)).not_to match_array(batch_notifications)
@@ -47,7 +47,7 @@ module Decidim
       end
 
       context "with wrong priority" do
-        let(:priority_level) { nil }
+        let(:priority) { nil }
 
         it "returns nothing" do
           expect(described_class.with_priority(priority).count).to eq(0)

--- a/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
@@ -15,6 +15,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
       event_name: notifications.first.event_name,
       user: notifications.first.user,
       extra: notifications.first.extra,
+      priority: notifications.first.priority,
       user_role: notifications.first.user_role,
       created_at: time_ago_in_words(notifications.first.created_at).capitalize
     }
@@ -40,7 +41,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
     end
 
     context "when the notifications are marked as low priority" do
-      let!(:notifications) { create_list(:notification, 2, :low_priority, user: user) }
+      let!(:notifications) { create_list(:notification, 2, user: user) }
 
       it "enqueues the job" do
         expect(Decidim::BatchNotificationsMailer)
@@ -84,7 +85,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
 
   describe "#events" do
     context "when the notifications are marked as low priority" do
-      let!(:notifications) { create_list(:notification, 2, :low_priority, user: user) }
+      let!(:notifications) { create_list(:notification, 2, user: user) }
 
       it "returns notifications" do
         expect(subject.send(:events)).to match_array(notifications)
@@ -101,7 +102,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
       end
 
       context "when notifications has already been sent" do
-        let!(:notifications) { create_list(:notification, 2, :low_priority, user: user) }
+        let!(:notifications) { create_list(:notification, 2, user: user) }
 
         before do
           notifications.first.update!(sent_at: 12.hours.ago)
@@ -117,9 +118,9 @@ describe Decidim::BatchEmailNotificationsGenerator do
 
   describe "#events_for" do
     context "when the notifications are marked as low priority" do
-      let!(:notifications) { create_list(:notification, 2, :low_priority, user: user) }
+      let!(:notifications) { create_list(:notification, 2, user: user) }
       let(:another_user) { create(:user) }
-      let(:notification) { create(:notification, :low_priority, user: another_user) }
+      let(:notification) { create(:notification, user: another_user) }
 
       before do
         Decidim.config.batch_email_notifications_max_length = 2
@@ -135,7 +136,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
 
   describe "#users" do
     context "when the notifications are marked as low priority" do
-      let!(:notifications) { create_list(:notification, 2, :low_priority, user: user) }
+      let!(:notifications) { create_list(:notification, 2, user: user) }
 
       it "returns users id" do
         expect(subject.send(:users)).to eq([user.id])

--- a/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
@@ -106,7 +106,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
       end
 
       context "when notifications has already been sent" do
-        let!(:notifications) { create_list(:notification, 2, user: user) }
+        let!(:notifications) { create_list(:notification, 3, user: user) }
 
         before do
           notifications.first.update!(sent_at: 12.hours.ago)
@@ -114,7 +114,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
 
         it "doesn't includes it" do
           expect(subject.send(:events)).not_to include(notifications.first)
-          expect(subject.send(:events).length).to eq(1)
+          expect(subject.send(:events).length).to eq(2)
         end
       end
     end
@@ -128,6 +128,10 @@ describe Decidim::BatchEmailNotificationsGenerator do
 
       before do
         Decidim.config.batch_email_notifications_max_length = 2
+      end
+
+      after do
+        Decidim.config.batch_email_notifications_max_length = 5
       end
 
       it "returns notifications for user" do

--- a/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
@@ -7,7 +7,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
   subject { described_class.new }
 
   let!(:user) { create(:user) }
-  let!(:notifications) { create_list(:notification, 2, user: user) }
+  let!(:notifications) { create_list(:notification, 2, :now_priority, user: user) }
   let(:serialized_event) do
     {
       resource: notifications.first.resource,
@@ -40,7 +40,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
       expect(Decidim::Notification.where(decidim_user_id: user.id).where.not(sent_at: nil).count).to eq(0)
     end
 
-    context "when the notifications are marked as low priority" do
+    context "when notifications are marked as batch priority" do
       let!(:notifications) { create_list(:notification, 2, user: user) }
 
       it "enqueues the job" do
@@ -84,7 +84,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
   end
 
   describe "#events" do
-    context "when the notifications are marked as low priority" do
+    context "when notifications are marked as batch priority" do
       let!(:notifications) { create_list(:notification, 2, user: user) }
 
       it "returns notifications" do
@@ -117,7 +117,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
   end
 
   describe "#events_for" do
-    context "when the notifications are marked as low priority" do
+    context "when notifications are marked as batch priority" do
       let!(:notifications) { create_list(:notification, 2, user: user) }
       let(:another_user) { create(:user) }
       let(:notification) { create(:notification, user: another_user) }
@@ -135,7 +135,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
   end
 
   describe "#users" do
-    context "when the notifications are marked as low priority" do
+    context "when notifications are marked as batch priority" do
       let!(:notifications) { create_list(:notification, 2, user: user) }
 
       it "returns users id" do

--- a/decidim-core/spec/services/decidim/events_manager_spec.rb
+++ b/decidim-core/spec/services/decidim/events_manager_spec.rb
@@ -12,6 +12,7 @@ describe Decidim::EventsManager do
     let(:followers) { create_list :user, 3, organization: organization }
     let(:affected_users) { create_list :user, 3, organization: organization }
     let(:force_send) { true }
+    let(:priority) { :batch }
 
     it "delegates the params to ActiveSupport::Notifications" do
       expect(ActiveSupport::Notifications)
@@ -23,6 +24,7 @@ describe Decidim::EventsManager do
           followers: followers,
           affected_users: affected_users,
           force_send: force_send,
+          priority: priority,
           extra: extra
         )
 
@@ -33,6 +35,7 @@ describe Decidim::EventsManager do
         followers: followers,
         affected_users: affected_users,
         force_send: force_send,
+        priority: priority,
         extra: extra
       )
     end
@@ -51,6 +54,7 @@ describe Decidim::EventsManager do
           resource: resource,
           followers: followers,
           affected_users: affected_users,
+          priority: priority,
           extra: extra
         )
       end
@@ -70,6 +74,7 @@ describe Decidim::EventsManager do
           resource: resource,
           followers: followers,
           affected_users: affected_users,
+          priority: priority,
           extra: extra
         )
       end

--- a/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
@@ -8,27 +8,27 @@ describe "rake decidim:batch_email_notifications:send", type: :task do
   let(:argument_error_output) { /Rake aborted !/ }
 
   context "when executing task" do
-    it "have to be executed without failures" do
-      expect(Decidim::BatchEmailNotificationsGeneratorJob).to receive(:perform_later)
-      Rake::Task[task_name].execute
+    it "raises an ArgumentError" do
+      Rake::Task[task_name].reenable
+      expect { Rake::Task[task_name].invoke }.to output(/ArgumentError : Rake aborted !/).to_stdout
     end
 
-    it "enqueues mailers" do
-      expect(Decidim::BatchEmailNotificationsGeneratorJob.queue_name).to eq "scheduled"
-    end
-
-    context "when batch_email_notifications_enabled is 'false'" do
+    context "when batch email notifications is enabled" do
       before do
-        Decidim.config.batch_email_notifications_enabled = false
-      end
-
-      after do
         Decidim.config.batch_email_notifications_enabled = true
       end
 
-      it "raises an ArgumentError" do
-        Rake::Task[task_name].reenable
-        expect { Rake::Task[task_name].invoke }.to output(/ArgumentError : Rake aborted !/).to_stdout
+      after do
+        Decidim.config.batch_email_notifications_enabled = false
+      end
+
+      it "has to be executed without failures" do
+        expect(Decidim::BatchEmailNotificationsGeneratorJob).to receive(:perform_later)
+        Rake::Task[task_name].execute
+      end
+
+      it "enqueues mailers" do
+        expect(Decidim::BatchEmailNotificationsGeneratorJob.queue_name).to eq "scheduled"
       end
     end
   end

--- a/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
+++ b/decidim-generators/lib/decidim/generators/app_templates/initializer.rb
@@ -224,6 +224,18 @@ Decidim.configure do |config|
   # Defines the name of the cookie used to check if the user allows Decidim to
   # set cookies.
   # config.consent_cookie_name = "decidim-cc"
+  #
+  #
+  # Decidim batch notifications in email
+  # Send multiple notifications in a unique mail
+  config.batch_email_notifications_enabled = false
+
+  # Time when the notification is considered as expired
+  # config.batch_email_notifications_expired = 1.week
+
+  # Maximum of notifications in a mail.
+  # If the number of notifications is greater than limit, displays a "see more" link in mail
+  # config.batch_email_notifications_max_length = 5
 end
 
 Rails.application.config.i18n.available_locales = Decidim.available_locales

--- a/decidim-initiatives/app/commands/decidim/initiatives/admin/send_initiative_to_technical_validation.rb
+++ b/decidim-initiatives/app/commands/decidim/initiatives/admin/send_initiative_to_technical_validation.rb
@@ -49,9 +49,7 @@ module Decidim
             resource: initiative,
             affected_users: affected_users,
             force_send: true,
-            extra: {
-              high_priority: true
-            }
+            priority: "now"
           }
 
           Decidim::EventsManager.publish(data)

--- a/decidim-initiatives/spec/commands/decidim/initiatives/admin/send_initiative_to_technical_validation_spec.rb
+++ b/decidim-initiatives/spec/commands/decidim/initiatives/admin/send_initiative_to_technical_validation_spec.rb
@@ -40,9 +40,7 @@ module Decidim
                 force_send: true,
                 resource: initiative,
                 affected_users: a_collection_containing_exactly(another_admin),
-                extra: {
-                  high_priority: true
-                }
+                priority: "now"
               )
 
             subject.call

--- a/decidim-meetings/app/commands/decidim/meetings/admin/validate_registration_code.rb
+++ b/decidim-meetings/app/commands/decidim/meetings/admin/validate_registration_code.rb
@@ -40,9 +40,9 @@ module Decidim
             event_class: Decidim::Meetings::RegistrationCodeValidatedEvent,
             resource: meeting,
             affected_users: [form.registration.user],
+            priority: "now",
             extra: {
-              registration: form.registration,
-              high_priority: true
+              registration: form.registration
             }
           )
         end

--- a/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/notify_role_assigned_to_participatory_process.rb
+++ b/decidim-participatory_processes/app/commands/decidim/participatory_processes/admin/notify_role_assigned_to_participatory_process.rb
@@ -11,9 +11,9 @@ module Decidim
             event_class: Decidim::ParticipatoryProcessRoleAssignedEvent,
             resource: form.current_participatory_space,
             affected_users: [user],
+            priority: "now",
             extra: {
-              role: form.role,
-              high_priority: true
+              role: form.role
             }
           )
         end

--- a/decidim-participatory_processes/spec/commands/create_participatory_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/commands/create_participatory_process_admin_spec.rb
@@ -28,9 +28,9 @@ module Decidim::ParticipatoryProcesses
         event_class: Decidim::ParticipatoryProcessRoleAssignedEvent,
         resource: my_process,
         affected_users: [user],
+        priority: "now",
         extra: {
-          role: kind_of(String),
-          high_priority: true
+          role: kind_of(String)
         }
       }
     end

--- a/decidim-participatory_processes/spec/commands/update_participatory_process_admin_spec.rb
+++ b/decidim-participatory_processes/spec/commands/update_participatory_process_admin_spec.rb
@@ -26,9 +26,9 @@ module Decidim::ParticipatoryProcesses
         event_class: Decidim::ParticipatoryProcessRoleAssignedEvent,
         resource: my_process,
         affected_users: [user],
+        priority: "now",
         extra: {
-          role: kind_of(String),
-          high_priority: true
+          role: kind_of(String)
         }
       }
     end

--- a/docs/customization/batch_email_notifications.md
+++ b/docs/customization/batch_email_notifications.md
@@ -3,35 +3,38 @@
 Batch email notifications are a way to send several email notifications at the same time.
 
 This is based on 3 parameters:
+
 - batch_email_notifications_enabled: Enable batch email notifications and disable single email notification (default to false)
+
 - batch_email_notifications_interval: Set interval to check for unsent notifications (default is 24 hours)
+
 - batch_email_notifications_max_length: Number of notifications to send in the same email (default to 5)
 
 ## How to setup?
+
 1. Cron setup
 
-Use `crontab -e` and enter the following lines:
+    Use `crontab -e` and enter the following lines:
 
-```
-0 0 * * * cd {MY_APP} && {/path/to/bundle} exec rake decidim:batch_email_notifications:send
-```
+    ```shell script
+    0 0 * * * cd {MY_APP} && {/path/to/bundle} exec rake decidim:batch_email_notifications:send
+    ```
 
-You could find the documentation about cron on [cron man page](https://www.man7.org/linux/man-pages/man8/cron.8.html)
+    You could find the documentation about cron on [cron man page](https://www.man7.org/linux/man-pages/man8/cron.8.html)
+1. Heroku scheduler
 
-2. Heroku scheduler
+    You can find information on how to setup heroku scheduler on [heroku documentation](https://devcenter.heroku.com/articles/scheduler)
 
-You can find information on how to setup heroku scheduler on [heroku documentation](https://devcenter.heroku.com/articles/scheduler)
+1. Sidekiq scheduler
 
-3. Sidekiq scheduler
+    In `config/sidekiq.yml`
 
-In `config/sidekiq.yml`
+    ```yaml
+    # sidekiq_scheduler.yml
 
-```
-# sidekiq_scheduler.yml
-
-batch_email_notifications:
-  every: ['6h', first_in: '1m']
-  class: Decidim::BatchEmailNotificationsGeneratorJob
-  queue: scheduled
-  description: 'This job executes batch email notifications'
-```
+    batch_email_notifications:
+      every: ['6h', first_in: '1m']
+      class: Decidim::BatchEmailNotificationsGeneratorJob
+      queue: scheduled
+      description: 'This job executes batch email notifications'
+    ```


### PR DESCRIPTION
#### :tophat: What? Why?

#### :clipboard: Subtasks
- [x] Change priority type to enum to be more flexible in future
- [x] Update `high` priority to `now` and `low` priority to `batch`
- [x] Refactor `Decidim::Notifications` and tests
- [x] Remove batch notifications interval
- [x] Only send unseen notifications
- [x] Create param `batch_email_notifications_expired`
- [x] Don't send notification which are older than param `batch_email_notifications_expired`, default: 1.week)
- [x] Set priority as top level parameter (not in extra)
- [x] Remove all extra priority in specs
- [x] Don't send notification set up as high priority in batch 
- [x] Complete documentation

