### PR TITLE
Fix address synchronization when update position 

### DIFF
--- a/decidim-core/app/assets/javascripts/decidim/map/controller/markers.js.es6
+++ b/decidim-core/app/assets/javascripts/decidim/map/controller/markers.js.es6
@@ -41,7 +41,7 @@
         const result = view.result[0];
         const address = result.location.address.label;
 
-        $(element).val(address);
+        $(`input[data-type="${element}"]`).val(address);
       });
     }
 
@@ -91,7 +91,7 @@
           marker.on("dragend", (ev) => {
             $(marker).trigger("geocoder-update-coordinates.decidim", {
               coordinates: ev.target.getLatLng(),
-              targetAddress: "#proposal_address"
+              targetAddress: "address"
             });
           });
         } else {

--- a/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
+++ b/decidim-proposals/app/views/decidim/proposals/proposals/preview.html.erb
@@ -17,7 +17,7 @@
         <%= decidim_form_for(@form, url: update_draft_proposal_path(@form), html: { method: :patch }) do |form| %>
           <%= form.hidden_field :title, value: form_presenter.title %>
           <%= form.hidden_field :body, value: form_presenter.body %>
-          <%= form.hidden_field :address %>
+          <%= form.hidden_field :address, data: { type: "address" } %>
           <%= form.hidden_field :latitude, data: { type: "latitude" } %>
           <%= form.hidden_field :longitude, data: { type: "longitude" } %>
           <div class="preview--form__hidden">

--- a/decidim-proposals/spec/shared/proposals_wizards_examples.rb
+++ b/decidim-proposals/spec/shared/proposals_wizards_examples.rb
@@ -181,6 +181,7 @@ shared_examples "proposals wizards" do |options|
         end
 
         it "shows a preview" do
+          expect(page).not_to have_content("You can move the point on the map.")
           expect(page).to have_content(proposal_title)
           expect(page).to have_content(user.name)
           expect(page).to have_content(proposal_body)
@@ -275,6 +276,7 @@ shared_examples "proposals wizards" do |options|
         end
 
         it "shows a preview" do
+          expect(page).to have_content("You can move the point on the map.")
           expect(page).to have_content(proposal_title)
           expect(page).to have_content(user.name)
           expect(page).to have_content(proposal_body)


### PR DESCRIPTION
#### :tophat: What? Why?

When user updates the cursor position on proposal map, coordinates are updated but not the address field. On submitting new position, the address is still the old one. 

#### :clipboard: Subtasks
- [x] Add reverse geocoding on drag and drop
- [x] Update the address field on `dragend`
- [ ] Add tests on drag and drop 
- [x] Keep the address field update generic

