### PR TITLE
Add priority on top level in notifications

### DIFF
--- a/decidim-core/app/commands/decidim/amendable/accept.rb
+++ b/decidim-core/app/commands/decidim/amendable/accept.rb
@@ -73,9 +73,7 @@ module Decidim
           resource: emendation,
           affected_users: affected_users.uniq,
           followers: followers.uniq,
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
       end
     end

--- a/decidim-core/app/commands/decidim/amendable/promote.rb
+++ b/decidim-core/app/commands/decidim/amendable/promote.rb
@@ -68,9 +68,7 @@ module Decidim
           resource: @emendation,
           affected_users: affected_users.uniq,
           followers: followers.uniq,
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
       end
 

--- a/decidim-core/app/commands/decidim/amendable/publish_draft.rb
+++ b/decidim-core/app/commands/decidim/amendable/publish_draft.rb
@@ -74,9 +74,7 @@ module Decidim
           resource: amendable,
           affected_users: amendable.notifiable_identities,
           followers: amendable.followers - amendable.notifiable_identities,
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
       end
     end

--- a/decidim-core/app/commands/decidim/amendable/reject.rb
+++ b/decidim-core/app/commands/decidim/amendable/reject.rb
@@ -58,9 +58,7 @@ module Decidim
           resource: @emendation,
           affected_users: affected_users.uniq,
           followers: followers.uniq,
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
       end
     end

--- a/decidim-core/app/models/decidim/user.rb
+++ b/decidim-core/app/models/decidim/user.rb
@@ -257,9 +257,7 @@ module Decidim
         event_class: WelcomeNotificationEvent,
         resource: self,
         affected_users: [self],
-        extra: {
-          high_priority: true
-        }
+        priority: "now"
       )
     end
 

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/accept_amendment_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/accept_amendment_examples.rb
@@ -52,9 +52,7 @@ shared_examples "accept amendment" do
           resource: emendation,
           followers: kind_of(Array),
           affected_users: kind_of(Array),
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
 
       command.call

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/promote_amendment_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/promote_amendment_examples.rb
@@ -33,9 +33,7 @@ shared_examples "promote amendment" do
           resource: emendation,
           affected_users: kind_of(Array),
           followers: kind_of(Array),
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
 
       command.call

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/publish_amendment_draft_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/publish_amendment_draft_examples.rb
@@ -35,9 +35,7 @@ shared_examples "publish amendment draft" do
           resource: amendable,
           affected_users: [amendable.creator_author],
           followers: [],
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
 
       command.call

--- a/decidim-core/lib/decidim/core/test/shared_examples/amendable/reject_amendment_examples.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/amendable/reject_amendment_examples.rb
@@ -33,9 +33,7 @@ shared_examples "reject amendment" do
           resource: emendation,
           affected_users: kind_of(Array),
           followers: kind_of(Array),
-          extra: {
-            high_priority: true
-          }
+          priority: "now"
         )
 
       command.call

--- a/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/batch_email_notifications_generator_spec.rb
@@ -21,7 +21,7 @@ describe Decidim::BatchEmailNotificationsGenerator do
     }
   end
 
-  describe "generate" do
+  describe "#generate" do
     let(:mailer) { double(deliver_later: true) }
 
     it "doesn't enqueues the job" do
@@ -146,8 +146,8 @@ describe Decidim::BatchEmailNotificationsGenerator do
     context "when notifications are marked as batch priority" do
       let!(:notifications) { create_list(:notification, 2, user: user) }
 
-      it "returns users id" do
-        expect(subject.send(:users)).to eq([user.id])
+      it "returns users" do
+        expect(subject.send(:users)).to eq([user])
       end
     end
   end


### PR DESCRIPTION
#### :tophat: What? Why?

Some notifications still had the deprecated priority system using `high_priority`.

#### :pushpin: Related Issues
- Related to #?
- Fixes #?

#### :clipboard: Subtasks
- [x] Update last notifications from `high_priority: true` to `priority: "now"`
