### PR TITLE
Fix notifications are not sent

### DIFF
--- a/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/email_notification_generator_job.rb
@@ -5,11 +5,11 @@ module Decidim
     queue_as :events
 
     # rubocop:disable Metrics/ParameterLists
-    def perform(event, event_class_name, resource, followers, affected_users, extra)
+    def perform(event, event_class_name, resource, followers, affected_users, priority, extra)
       return if event_class_name.nil?
 
       event_class = event_class_name.constantize
-      EmailNotificationGenerator.new(event, event_class, resource, followers, affected_users, extra).generate
+      EmailNotificationGenerator.new(event, event_class, resource, followers, affected_users, priority, extra).generate
     end
     # rubocop:enable Metrics/ParameterLists
   end

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -65,11 +65,10 @@ module Decidim
     def high_priority?(data)
       return false if data[:priority].blank?
 
-      data[:priority] = data[:priority].to_sym if data[:priority].is_a? String
-
+      data[:priority] = data[:priority].to_s if data[:priority].is_a? Symbol
       return false unless Decidim::Notification.priorities.include? data[:priority]
 
-      data[:priority] == :now
+      data[:priority] == "now"
     end
   end
 end

--- a/decidim-core/app/jobs/decidim/event_publisher_job.rb
+++ b/decidim-core/app/jobs/decidim/event_publisher_job.rb
@@ -53,6 +53,7 @@ module Decidim
         data[:resource],
         data[:followers],
         data[:affected_users],
+        data[:priority],
         data[:extra]
       )
     end

--- a/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_for_recipient_job.rb
@@ -4,10 +4,10 @@ module Decidim
   class NotificationGeneratorForRecipientJob < ApplicationJob
     queue_as :events
 
-    def perform(event, event_class_name, resource, recipient, user_role, extra) # rubocop:disable Metrics/ParameterLists
+    def perform(event, event_class_name, resource, recipient, user_role, priority, extra) # rubocop:disable Metrics/ParameterLists
       event_class = event_class_name.constantize
       NotificationGeneratorForRecipient
-        .new(event, event_class, resource, recipient, user_role, extra)
+        .new(event, event_class, resource, recipient, user_role, priority, extra)
         .generate
     end
   end

--- a/decidim-core/app/jobs/decidim/notification_generator_job.rb
+++ b/decidim-core/app/jobs/decidim/notification_generator_job.rb
@@ -5,11 +5,11 @@ module Decidim
     queue_as :events
 
     # rubocop:disable Metrics/ParameterLists
-    def perform(event, event_class_name, resource, followers, affected_users, extra)
+    def perform(event, event_class_name, resource, followers, affected_users, priority, extra)
       return unless defined?(event_class_name.constantize)
 
       event_class = event_class_name.constantize
-      NotificationGenerator.new(event, event_class, resource, followers, affected_users, extra).generate
+      NotificationGenerator.new(event, event_class, resource, followers, affected_users, priority, extra).generate
     end
     # rubocop:enable Metrics/ParameterLists
   end

--- a/decidim-core/app/mailers/decidim/notification_mailer.rb
+++ b/decidim-core/app/mailers/decidim/notification_mailer.rb
@@ -6,13 +6,13 @@ module Decidim
   class NotificationMailer < Decidim::ApplicationMailer
     helper Decidim::ResourceHelper
 
-    def event_received(event, event_class_name, resource, user, user_role, extra) # rubocop:disable Metrics/ParameterLists
+    def event_received(event, event_class_name, resource, user, user_role, priority, extra) # rubocop:disable Metrics/ParameterLists
       return if user.email.blank?
 
       with_user(user) do
         @organization = user.organization
         event_class = event_class_name.constantize
-        @event_instance = event_class.new(resource: resource, event_name: event, user: user, extra: extra, user_role: user_role)
+        @event_instance = event_class.new(resource: resource, event_name: event, user: user, priority: priority, extra: extra, user_role: user_role)
         subject = @event_instance.email_subject
 
         mail(to: user.email, subject: subject)

--- a/decidim-core/app/models/decidim/notification.rb
+++ b/decidim-core/app/models/decidim/notification.rb
@@ -19,6 +19,7 @@ module Decidim
         event_name: event_name,
         user: user,
         user_role: user_role,
+        priority: priority,
         extra: extra
       )
     end

--- a/decidim-core/app/services/decidim/email_notification_generator.rb
+++ b/decidim-core/app/services/decidim/email_notification_generator.rb
@@ -16,14 +16,16 @@ module Decidim
     #   they're following it
     # affected_users - a collection of Users that receive the notification because
     #   they're affected by it
+    # priority - a String. If batch notifications enabled, define if the notification has to be sent directly. By default Batch
     # extra - a Hash with extra information to be included in the notification.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(event, event_class, resource, followers, affected_users, extra)
+    def initialize(event, event_class, resource, followers, affected_users, priority, extra)
       @event = event
       @event_class = event_class
       @resource = resource
       @followers = followers
       @affected_users = affected_users
+      @priority = priority
       @extra = extra
     end
     # rubocop:enable Metrics/ParameterLists
@@ -52,7 +54,7 @@ module Decidim
 
     private
 
-    attr_reader :event, :event_class, :resource, :followers, :affected_users, :extra
+    attr_reader :event, :event_class, :resource, :followers, :affected_users, :priority, :extra
 
     # Private: sends the notification email to the user if they have the
     # `email_on_notification` flag active.
@@ -74,6 +76,7 @@ module Decidim
           resource,
           recipient,
           user_role.to_s,
+          priority,
           extra
         )
         .deliver_later

--- a/decidim-core/app/services/decidim/events_manager.rb
+++ b/decidim-core/app/services/decidim/events_manager.rb
@@ -20,6 +20,7 @@ module Decidim
     #   the event, even though it doesn't affect them directly
     # force_send - boolean indicating if EventPublisherJob should skip the
     #   `notifiable?` check it performs before notifying. Defaults to __false__.
+    # priority - a String. If batch notifications enabled, define if the notification has to be sent directly. By default Batch
     # extra - a Hash with extra information to be included in the notification.
     #
     # Returns nothing.

--- a/decidim-core/app/services/decidim/notification_generator.rb
+++ b/decidim-core/app/services/decidim/notification_generator.rb
@@ -16,14 +16,16 @@ module Decidim
     #   they're following it
     # affected_users - a collection of Users that receive the notification because
     #   they're affected by it
+    # priority - a String. If batch notifications enabled, define if the notification has to be sent directly. By default Batch
     # extra - a Hash with extra information for the event.
     # rubocop:disable Metrics/ParameterLists
-    def initialize(event, event_class, resource, followers, affected_users, extra)
+    def initialize(event, event_class, resource, followers, affected_users, priority, extra)
       @event = event
       @event_class = event_class
       @resource = resource
       @followers = followers
       @affected_users = affected_users
+      @priority = priority
       @extra = extra
     end
     # rubocop:enable Metrics/ParameterLists
@@ -47,7 +49,7 @@ module Decidim
 
     private
 
-    attr_reader :event, :event_class, :resource, :followers, :affected_users, :extra
+    attr_reader :event, :event_class, :resource, :followers, :affected_users, :priority, :extra
 
     def generate_notification_for(recipient, user_role:)
       return if resource.respond_to?(:can_participate?) && !resource.can_participate?(recipient)
@@ -58,6 +60,7 @@ module Decidim
         resource,
         recipient,
         user_role.to_s,
+        priority,
         extra
       )
     end

--- a/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
+++ b/decidim-core/app/services/decidim/notification_generator_for_recipient.rb
@@ -12,13 +12,15 @@ module Decidim
     # event_class - The class that wraps the event, in order to decorate it.
     # resource - an instance of a class implementing the `Decidim::Resource` concern.
     # recipient - the User that will receive the notification.
+    # priority - a String. If batch notifications enabled, define if the notification has to be sent directly. By default Batch
     # extra - a Hash with extra information to be included in the notification.
-    def initialize(event, event_class, resource, recipient, user_role, extra) # rubocop:disable Metrics/ParameterLists
+    def initialize(event, event_class, resource, recipient, user_role, priority, extra) # rubocop:disable Metrics/ParameterLists
       @event = event
       @event_class = event_class
       @resource = resource
       @recipient = recipient
       @user_role = user_role
+      @priority = priority
       @extra = extra
     end
 
@@ -42,10 +44,11 @@ module Decidim
         event_class: event_class,
         resource: resource,
         event_name: event,
+        priority: priority,
         extra: extra.merge(received_as: user_role)
       )
     end
 
-    attr_reader :event, :event_class, :resource, :recipient, :user_role, :extra
+    attr_reader :event, :event_class, :resource, :recipient, :user_role, :priority, :extra
   end
 end

--- a/decidim-core/lib/decidim/core/test/shared_examples/logo_email.rb
+++ b/decidim-core/lib/decidim/core/test/shared_examples/logo_email.rb
@@ -6,7 +6,7 @@ shared_examples "email with logo" do
   context "when organization has a logo" do
     let(:organization_logo) { Decidim::Dev.test_file("city.jpeg", "image/jpeg") }
     let(:organization) { create(:organization, logo: organization_logo) }
-    let(:mail) { described_class.event_received(event, event_class_name, resource, user, :follower, extra) }
+    let(:mail) { described_class.event_received(event, event_class_name, resource, user, :follower, priority, extra) }
 
     it "includes organization logo" do
       expect(mail.body).to include(organization.logo.medium.url)

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -44,6 +44,7 @@ module Decidim
       #   `:affected_user`)
       # priority - a String : If batch notifications enabled, define if the notification has to be sent directly. By default Batch
       # extra - a Hash with extra information of the event.
+      # rubocop:disable Metrics/ParameterLists
       def initialize(resource:, event_name:, user:, user_role: nil, priority: "batch", extra: {})
         @event_name = event_name
         @resource = resource
@@ -52,6 +53,7 @@ module Decidim
         @priority = priority
         @extra = extra.with_indifferent_access
       end
+      # rubocop:enable Metrics/ParameterLists
 
       # Caches the locator for the given resource, so that
       # we can find the resource URL.

--- a/decidim-core/lib/decidim/events/base_event.rb
+++ b/decidim-core/lib/decidim/events/base_event.rb
@@ -42,12 +42,14 @@ module Decidim
       # user - the User that receives the event
       # user_role - the role the user takes for this event (either `:follower` or
       #   `:affected_user`)
+      # priority - a String : If batch notifications enabled, define if the notification has to be sent directly. By default Batch
       # extra - a Hash with extra information of the event.
-      def initialize(resource:, event_name:, user:, user_role: nil, extra: {})
+      def initialize(resource:, event_name:, user:, user_role: nil, priority: "batch", extra: {})
         @event_name = event_name
         @resource = resource
         @user = user
         @user_role = user_role
+        @priority = priority
         @extra = extra.with_indifferent_access
       end
 
@@ -97,7 +99,7 @@ module Decidim
         resource.try(:participatory_space)
       end
 
-      attr_reader :event_name, :resource, :user, :user_role, :extra
+      attr_reader :event_name, :resource, :user, :user_role, :priority, :extra
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/email_notification_generator_job_spec.rb
@@ -21,17 +21,18 @@ describe Decidim::EmailNotificationGeneratorJob do
     let(:affected_users) { [affected_user] }
     let(:follower) { double :user, id: 2 }
     let(:followers) { [follower] }
+    let(:priority) { double }
     let(:extra) { double }
 
     it "delegates the work to the class" do
       expect(Decidim::EmailNotificationGenerator)
         .to receive(:new)
-        .with(event, event_class, resource, followers, affected_users, extra)
+        .with(event, event_class, resource, followers, affected_users, priority, extra)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
+      subject.perform_now(event, event_class_name, resource, followers, affected_users, priority, extra)
     end
 
     context "when event_class_name is nil" do
@@ -39,7 +40,7 @@ describe Decidim::EmailNotificationGeneratorJob do
 
       it "does not raise error" do
         expect do
-          subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
+          subject.perform_now(event, event_class_name, resource, followers, affected_users, priority, extra)
         end.not_to raise_error
       end
     end

--- a/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_for_recipient_job_spec.rb
@@ -17,18 +17,19 @@ describe Decidim::NotificationGeneratorForRecipientJob do
     let(:event_class_name) { "Decidim::Events::BaseEvent" }
     let(:resource) { double :resource }
     let(:recipient) { double :recipient }
+    let(:priority) { double }
     let(:extra) { double }
     let(:generator) { double :generator }
 
     it "delegates the work to the class" do
       expect(Decidim::NotificationGeneratorForRecipient)
         .to receive(:new)
-        .with(event, event_class, resource, recipient, :follower, extra)
+        .with(event, event_class, resource, recipient, :follower, priority, extra)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, resource, recipient, :follower, extra)
+      subject.perform_now(event, event_class_name, resource, recipient, :follower, priority, extra)
     end
   end
 end

--- a/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
+++ b/decidim-core/spec/jobs/decidim/notification_generator_job_spec.rb
@@ -21,17 +21,18 @@ describe Decidim::NotificationGeneratorJob do
     let(:affected_users) { [affected_user] }
     let(:follower) { double :user, id: 2 }
     let(:followers) { [follower] }
+    let(:priority) { double }
     let(:extra) { double }
 
     it "delegates the work to the class" do
       expect(Decidim::NotificationGenerator)
         .to receive(:new)
-        .with(event, event_class, resource, followers, affected_users, extra)
+        .with(event, event_class, resource, followers, affected_users, priority, extra)
         .and_return(generator)
       expect(generator)
         .to receive(:generate)
 
-      subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
+      subject.perform_now(event, event_class_name, resource, followers, affected_users, priority, extra)
     end
 
     context "when event_class_name is nil" do
@@ -39,7 +40,7 @@ describe Decidim::NotificationGeneratorJob do
 
       it "does not raise error" do
         expect do
-          subject.perform_now(event, event_class_name, resource, followers, affected_users, extra)
+          subject.perform_now(event, event_class_name, resource, followers, affected_users, priority, extra)
         end.not_to raise_error
       end
     end

--- a/decidim-core/spec/lib/events/base_event_spec.rb
+++ b/decidim-core/spec/lib/events/base_event_spec.rb
@@ -9,6 +9,7 @@ module Decidim
         resource: resource,
         event_name: "some.event",
         user: user,
+        priority: "now",
         extra: {}
       )
     end

--- a/decidim-core/spec/mailers/notification_mailer_spec.rb
+++ b/decidim-core/spec/mailers/notification_mailer_spec.rb
@@ -10,12 +10,13 @@ module Decidim
     let(:event_class_name) { "Decidim::ProfileUpdatedEvent" }
     let(:extra) { { foo: "bar" } }
     let(:event) { "decidim.events.users.profile_updated" }
+    let(:priority) { "batch" }
     let(:event_instance) do
-      event_class_name.constantize.new(resource: resource, event_name: event, user: user, user_role: :follower, extra: extra)
+      event_class_name.constantize.new(resource: resource, event_name: event, user: user, user_role: :follower, priority: priority, extra: extra)
     end
 
     describe "event_received" do
-      let(:mail) { described_class.event_received(event, event_class_name, resource, user, :follower, extra) }
+      let(:mail) { described_class.event_received(event, event_class_name, resource, user, :follower, priority, extra) }
 
       it "gets the subject from the event" do
         expect(mail.subject).to include("updated their profile")

--- a/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/email_notification_generator_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::EmailNotificationGenerator do
-  subject { described_class.new(event, event_class, resource, followers, affected_users, extra) }
+  subject { described_class.new(event, event_class, resource, followers, affected_users, priority, extra) }
 
   let(:event) { "decidim.events.dummy.dummy_resource_updated" }
   let(:resource) { create(:dummy_resource) }
@@ -14,6 +14,7 @@ describe Decidim::EmailNotificationGenerator do
   let(:affected_users) { [recipient] }
   let(:follower) { create :user }
   let(:followers) { [follower] }
+  let(:priority) { double }
   let(:extra) { double }
 
   describe "generate" do
@@ -47,12 +48,12 @@ describe Decidim::EmailNotificationGenerator do
         it "schedules a job for each recipient" do
           expect(Decidim::NotificationMailer)
             .to receive(:event_received)
-            .with(event, event_class_name, resource, recipient, :affected_user.to_s, extra)
+            .with(event, event_class_name, resource, recipient, :affected_user.to_s, priority, extra)
             .and_return(mailer)
 
           expect(Decidim::NotificationMailer)
             .to receive(:event_received)
-            .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+            .with(event, event_class_name, resource, follower, :follower.to_s, priority, extra)
             .and_return(mailer)
 
           expect(mailer).to receive(:deliver_later)
@@ -73,12 +74,12 @@ describe Decidim::EmailNotificationGenerator do
           it "enqueues the job" do
             expect(Decidim::NotificationMailer)
               .to receive(:event_received)
-              .with(event, event_class_name, resource, recipient, :affected_user.to_s, extra)
+              .with(event, event_class_name, resource, recipient, :affected_user.to_s, priority, extra)
               .and_return(mailer)
 
             expect(Decidim::NotificationMailer)
               .to receive(:event_received)
-              .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+              .with(event, event_class_name, resource, follower, :follower.to_s, priority, extra)
               .and_return(mailer)
 
             expect(mailer).to receive(:deliver_later)

--- a/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_for_recipient_spec.rb
@@ -3,12 +3,13 @@
 require "spec_helper"
 
 describe Decidim::NotificationGeneratorForRecipient do
-  subject { described_class.new(event, event_class, resource, recipient, :affected_user, extra) }
+  subject { described_class.new(event, event_class, resource, recipient, :affected_user, priority, extra) }
 
   let(:event) { "decidim.events.dummy.dummy_resource_updated" }
   let(:resource) { create(:dummy_resource, published_at: Time.current) }
   let(:follow) { create(:follow, followable: resource, user: recipient) }
   let(:recipient) { resource.author }
+  let(:priority) { "batch" }
   let(:extra) { {} }
   let(:event_class) { Decidim::Events::BaseEvent }
 
@@ -22,6 +23,7 @@ describe Decidim::NotificationGeneratorForRecipient do
       expect(notification.user).to eq recipient
       expect(notification.event_name).to eq event
       expect(notification.resource).to eq resource
+      expect(notification.priority).to eq priority
       expect(notification.extra["received_as"]).to eq "affected_user"
     end
   end

--- a/decidim-core/spec/services/decidim/notification_generator_spec.rb
+++ b/decidim-core/spec/services/decidim/notification_generator_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 
 describe Decidim::NotificationGenerator do
-  subject { described_class.new(event, event_class, resource, followers, affected_users, extra) }
+  subject { described_class.new(event, event_class, resource, followers, affected_users, priority, extra) }
 
   let(:event) { "decidim.events.dummy.dummy_resource_updated" }
   let(:resource) { create(:dummy_resource) }
@@ -14,6 +14,7 @@ describe Decidim::NotificationGenerator do
   let(:affected_users) { [affected_user] }
   let(:follower) { create :user }
   let(:followers) { [follower] }
+  let(:priority) { double }
   let(:extra) { double }
 
   describe "generate" do
@@ -31,7 +32,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .to receive(:perform_later)
-              .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+              .with(event, event_class_name, resource, follower, :follower.to_s, priority, extra)
             subject.generate
           end
         end
@@ -42,7 +43,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .to receive(:perform_later)
-              .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+              .with(event, event_class_name, resource, follower, :follower.to_s, priority, extra)
             subject.generate
           end
         end
@@ -53,7 +54,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .not_to receive(:perform_later)
-              .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+              .with(event, event_class_name, resource, follower, :follower.to_s, priority, extra)
             subject.generate
           end
         end
@@ -64,7 +65,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .not_to receive(:perform_later)
-              .with(event, event_class_name, resource, follower, :follower.to_s, extra)
+              .with(event, event_class_name, resource, follower, :follower.to_s, priority, extra)
             subject.generate
           end
         end
@@ -79,7 +80,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .to receive(:perform_later)
-              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, extra)
+              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, priority, extra)
             subject.generate
           end
         end
@@ -90,7 +91,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .not_to receive(:perform_later)
-              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, extra)
+              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, priority, extra)
             subject.generate
           end
         end
@@ -101,7 +102,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .not_to receive(:perform_later)
-              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, extra)
+              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, priority, extra)
             subject.generate
           end
         end
@@ -112,7 +113,7 @@ describe Decidim::NotificationGenerator do
           it "sends the notification" do
             expect(Decidim::NotificationGeneratorForRecipientJob)
               .to receive(:perform_later)
-              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, extra)
+              .with(event, event_class_name, resource, affected_user, :affected_user.to_s, priority, extra)
             subject.generate
           end
         end

--- a/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
@@ -7,6 +7,10 @@ describe "rake decidim:batch_email_notifications:send", type: :task do
   let(:task_name) { :"decidim:batch_email_notifications:send" }
   let(:argument_error_output) { /Rake aborted !/ }
 
+  let!(:user) { create(:user) }
+  let!(:notifications) { create_list(:notification, 2, user: user) }
+  let!(:now_notifications) { create_list(:notification, 3, :now_priority, user: user) }
+
   context "when executing task" do
     it "raises an ArgumentError" do
       Rake::Task[task_name].reenable
@@ -25,6 +29,12 @@ describe "rake decidim:batch_email_notifications:send", type: :task do
       it "has to be executed without failures" do
         expect(Decidim::BatchEmailNotificationsGeneratorJob).to receive(:perform_later)
         Rake::Task[task_name].execute
+      end
+
+      it "send the batch notifications only" do
+        expect(Decidim::Notification.where(sent_at:nil).count).to eq(5)
+        Rake::Task[task_name].execute
+        expect(Decidim::Notification.where.not(sent_at:nil).count).to eq(3)
       end
 
       it "enqueues mailers" do

--- a/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
@@ -7,10 +7,6 @@ describe "rake decidim:batch_email_notifications:send", type: :task do
   let(:task_name) { :"decidim:batch_email_notifications:send" }
   let(:argument_error_output) { /Rake aborted !/ }
 
-  let!(:user) { create(:user) }
-  let!(:notifications) { create_list(:notification, 2, user: user) }
-  let!(:now_notifications) { create_list(:notification, 3, :now_priority, user: user) }
-
   context "when executing task" do
     it "raises an ArgumentError" do
       Rake::Task[task_name].reenable
@@ -29,12 +25,6 @@ describe "rake decidim:batch_email_notifications:send", type: :task do
       it "has to be executed without failures" do
         expect(Decidim::BatchEmailNotificationsGeneratorJob).to receive(:perform_later)
         Rake::Task[task_name].execute
-      end
-
-      it "send the batch notifications only" do
-        expect(Decidim::Notification.where(sent_at: nil).count).to eq(5)
-        Rake::Task[task_name].execute
-        expect(Decidim::Notification.where.not(sent_at: nil).count).to eq(3)
       end
 
       it "enqueues mailers" do

--- a/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
+++ b/decidim-core/spec/tasks/decidim_tasks_batch_email_notifications_spec.rb
@@ -32,9 +32,9 @@ describe "rake decidim:batch_email_notifications:send", type: :task do
       end
 
       it "send the batch notifications only" do
-        expect(Decidim::Notification.where(sent_at:nil).count).to eq(5)
+        expect(Decidim::Notification.where(sent_at: nil).count).to eq(5)
         Rake::Task[task_name].execute
-        expect(Decidim::Notification.where.not(sent_at:nil).count).to eq(3)
+        expect(Decidim::Notification.where.not(sent_at: nil).count).to eq(3)
       end
 
       it "enqueues mailers" do


### PR DESCRIPTION
#### :tophat: What? Why?

I noticed that batch notifications is not completely functional at the moment. In fact, batch emails are not sent. 

With this PR, you can test the behaviour of notifications with and without batch notifications. 

#### :pushpin: Additional informations
- I have tested this behaviour in-app using the following events`Decidim::Debates::CreateDebateEvent` and `Decidim::Debates::CloseDebateEvent`
- What I tried is to disable and enable batch notifications. When enabled, I tried to generate the `CloseDebateEvent` using `batch` and also `now` priority. It seems to work.
- Furthermore, I've tested to mark a notification as read and ensure this one is not sent by email. It works too

I have encountered some difficulties to test batch email notification because of the queues in local environment. Switch `perform_later` to `perform_now` and `deliver_later` to `deliver_now` allowed me to test it.

#### :clipboard: Subtasks
- [x] Add priority to Notifications
- [x] Refactor `high_priority?` method because it was failing in async thread
- [x] Add tests
- [ ] Check that notification behaviour with batch disabled is still functional
